### PR TITLE
template message patch

### DIFF
--- a/docs/apis/messages.md
+++ b/docs/apis/messages.md
@@ -105,13 +105,22 @@ itchatmp.messages.send_all(TEXT, 'this is a sendall')
 ```python
 templateId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 msgDict = {
-    'title': 'Title',
-    'user': 'User',
-    'content': 'Content', }
+    'title': {'value': 'Title'},
+    'user': {'value': 'User'},
+    'content': {'value': 'Content', 'color': '#173177'}, }
 toUserName = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 
 r = itchatmp.templatemsgs.send(templateId, msgDict, toUserName)
 print(r)
 ```
+
+如果想在模版中加入可点链接, 在msgDict中加入url：
+```python
+msgDict = {
+    'title': {'value': 'Title'},
+    'user': {'value': 'User'},
+    'content': {'value': 'Content', 'color': '#173177'},
+    'url': 'www.github.com', }
+ ```
 
 [mp-wiki]: https://mp.weixin.qq.com/wiki

--- a/itchatmp/controllers/mpapi/mp/templatemsgs.py
+++ b/itchatmp/controllers/mpapi/mp/templatemsgs.py
@@ -64,11 +64,12 @@ def get_templates(accessToken=None):
 
 def send(templateId, msgDict, toUserId, accessToken=None):
     ''' send template to your massive platform users '''
-    msgDict = copy.deepcopy(msgDict)
-    msgDict['touser'], msgDict['template_id'] = toUserId, templateId
+    url = msgDict.pop('url', None)
+    msgDict['data'] = copy.deepcopy(msgDict)
+    msgDict['touser'], msgDict['template_id'], msgDict['url'] = toUserId, templateId, url
     data = encode_send_dict(msgDict)
     if data is None: return ReturnValue({'errcode': -10001})
-    r = requests.post('%s/cgi-bin/template/del_private_template?access_token=%s' % 
+    r = requests.post('%s/cgi-bin/message/template/send?access_token=%s' %
         (SERVER_URL, accessToken), data=data)
     def _wrap_result(result):
         return ReturnValue(result.json())


### PR DESCRIPTION
_I have closed the old one, because I need to make a new branch to fix more code. >\_<_

# First. 
fixed a typo in the send template function #20 

# Second.
Wechat has changed its template message data struct.
New Struct require a separate data field. 
```      
{
           "touser":"OPENID",
           "template_id":"ngqIpbwh8bUfcSsECmogfXcV14J0tQlEpBO27izEYtY",
           "url":"http://weixin.qq.com/download",  
           "miniprogram":{
             "appid":"xiaochengxuappid12345",
             "pagepath":"index?foo=bar"
           },          
           "data":{
                   "first": {
                       "value":"恭喜你购买成功！",
                       "color":"#173177"
                   },
                   "keynote1":{
                       "value":"巧克力",
                       "color":"#173177"
                   },
                   "keynote2": {
                       "value":"39.8元",
                       "color":"#173177"
                   },
                   "keynote3": {
                       "value":"2014年9月22日",
                       "color":"#173177"
                   },
                   "remark":{
                       "value":"欢迎再次购买！",
                       "color":"#173177"
                   }
           }
       }

```
# Third.
Also added url and color option which I thought might be useful to other people.

I have changed the code and tested it. 