### PR TITLE
Connection Pool overflow

### DIFF
--- a/itchatmp/controllers/mpapi/requests/__init__.py
+++ b/itchatmp/controllers/mpapi/requests/__init__.py
@@ -10,5 +10,7 @@ if COROUTINE:
 else:
     import requests
     requests.packages.urllib3.disable_warnings()
+    adapters = requests.adapters.HTTPAdapter(pool_connections=100, pool_maxsize=100)
     requests = requests.session()
+    requests.mount('https://', adapters)
     requests.verify = False


### PR DESCRIPTION
when too many request are being posted at the same time the following warning shows
``` python
Connection pool is full, discarding connection
```
this fixes the warning by increasing the pool size to 100

Tian